### PR TITLE
ブラウザのキャッシュを使用してログイン処理をスキップする

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ TOKYO_42_USERNAME="sample_user"
 TOKYO_42_PASSWORD="password"
 FT_URL="https://projects.intra.42.fr/projects/<project-name>/slots?team_id=<id>"
 DISCORD_WEBHOOK_URL="<webhook-url>"
+ENVIRONMENT=browser # ブラウザのキャッシュを使用したい場合に指定する
+BROWSER_EXECUTABLE_PATH="/snap/bin/chromium" # snapでinstallしたchromiumの場合 (which chromium-browserで取得可能)
+USER_DATA_DIR="/home/<username>/snap/chromium/common/chromium" # snapでinstallしたchromiumの場合 (chrome://versionを確認するとそれっぽいものが確認できるかも)
 EOF
 $ npm install -g yarn
 $ yarn

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,8 @@ const launchBrowser = async () => {
       configs.slowMo = 10;
       break;
     case "browser":
-      configs.executablePath = "/opt/google/chrome/google-chrome";
-      configs.userDataDir = process.env.HOME + "/.config/google-chrome/";
+      configs.executablePath = process.env.BROWSER_EXECUTABLE_PATH;
+      configs.userDataDir = process.env.USER_DATA_DIR;
       break;
   }
   return puppeteer.launch(configs);


### PR DESCRIPTION
closes #3 

高頻度でログイン処理を行うと、ログイン通知が煩わしくなる。
できればログイン通知を減らしたい。
今回は、ブラウザのキャッシュを使用し、ログイン処理をスキップすることで対応した。

対応のためのREADMEも合わせて更新した